### PR TITLE
Improve todo and notes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,8 +27,9 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.red),
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
         useMaterial3: true,
+        scaffoldBackgroundColor: Colors.white,
       ),
       home: const HomeScreen(),
     );
@@ -72,7 +73,11 @@ class _HomeScreenState extends State<HomeScreen> {
 
   void _toggleTodoDone(int index) {
     setState(() {
-      _todos[index].isDone = !_todos[index].isDone;
+      final todo = _todos[index];
+      todo.isDone = !todo.isDone;
+      if (todo.isDone) {
+        _todos.removeAt(index);
+      }
     });
   }
 
@@ -201,6 +206,13 @@ class NotesListPage extends StatelessWidget {
           return ListTile(
             title: Text(note.title),
             subtitle: Text(_formatDate(note.date)),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => NoteDetailPage(note: note),
+                ),
+              );
+            },
           );
         },
       ),
@@ -246,6 +258,45 @@ class TodoListPage extends StatelessWidget {
         onPressed: onAdd,
         tooltip: 'Add Todo',
         child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+class NoteDetailPage extends StatelessWidget {
+  final Note note;
+
+  const NoteDetailPage({super.key, required this.note});
+
+  String _formatDate(DateTime date) {
+    String twoDigits(int n) => n.toString().padLeft(2, '0');
+    return '${date.year}/${twoDigits(date.month)}/${twoDigits(date.day)} '
+        '${twoDigits(date.hour)}:${twoDigits(date.minute)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('メモ詳細'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(note.title,
+                style: Theme.of(context).textTheme.headlineSmall),
+            const SizedBox(height: 8),
+            Text(
+              _formatDate(note.date),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 16),
+            Text(note.body),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- tune theme to use blue primary color and white scaffold background
- remove todo item when marked complete
- allow tapping a note to open detail page
- add note detail page to show note title, date, and body

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dba796f58832bbd11e784efc3f512